### PR TITLE
Improve mobile header responsiveness

### DIFF
--- a/src/components/common/Header.js
+++ b/src/components/common/Header.js
@@ -244,13 +244,14 @@ const Header = ({ elevation = 0 }) => {
   return (
     <>
       <HideOnScroll>
-        <AppBar 
-          position="fixed" 
+        <AppBar
+          position="fixed"
           elevation={0}
           sx={headerStyle}
+          className="app-header"
         >
           <Container maxWidth="lg">
-            <Toolbar sx={{ justifyContent: 'space-between', py: 1 }}>
+            <Toolbar className="header-toolbar" sx={{ justifyContent: 'space-between', py: 1 }}>
               {/* Logo/Nome */}
               <motion.div
                 initial={{ opacity: 0, x: -20 }}
@@ -261,6 +262,7 @@ const Header = ({ elevation = 0 }) => {
                   variant="h5"
                   component={Link}
                   to="/"
+                  className="header-title"
                   sx={{
                     textDecoration: 'none',
                     color: 'primary.main',
@@ -296,6 +298,7 @@ const Header = ({ elevation = 0 }) => {
                       <Button
                         component={Link}
                         to={item.path}
+                        className="nav-button"
                         sx={getLinkStyle(item.path)}
                       >
                         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -285,3 +285,23 @@ html {
     page-break-after: avoid;
   }
 }
+
+/* ===================================================================
+   EXTRA RESPONSIVE RULES
+   =================================================================== */
+
+@media (max-width: 480px) {
+  .app-header .header-toolbar {
+    padding-top: 4px;
+    padding-bottom: 4px;
+  }
+
+  .header-title {
+    font-size: 1rem;
+  }
+
+  .nav-button {
+    padding: 6px 8px;
+    margin: 0 2px;
+  }
+}


### PR DESCRIPTION
## Summary
- add CSS mobile rules for header
- add classes on header elements for easier styling

## Testing
- `CI=true npm test --silent` *(fails: MUI palette configuration)*

------
https://chatgpt.com/codex/tasks/task_e_688bdf58ec888328ac18d30eed6e9d76